### PR TITLE
Add player and game channels

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -18,15 +18,17 @@
 // Include phoenix_html to handle method=PUT/DELETE in forms and buttons.
 import "phoenix_html"
 // Establish Phoenix Socket and LiveView configuration.
-import {Socket} from "phoenix"
-import {LiveSocket} from "phoenix_live_view"
+import { Socket } from "phoenix"
+import { LiveSocket } from "phoenix_live_view"
 import topbar from "../vendor/topbar"
 
+import "./new_game_socket.js"
+
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
-let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}})
+let liveSocket = new LiveSocket("/live", Socket, { params: { _csrf_token: csrfToken } })
 
 // Show progress bar on live navigation and form submits
-topbar.config({barColors: {0: "#29d"}, shadowColor: "rgba(0, 0, 0, .3)"})
+topbar.config({ barColors: { 0: "#29d" }, shadowColor: "rgba(0, 0, 0, .3)" })
 window.addEventListener("phx:page-loading-start", _info => topbar.show(300))
 window.addEventListener("phx:page-loading-stop", _info => topbar.hide())
 

--- a/assets/js/new_game_socket.js
+++ b/assets/js/new_game_socket.js
@@ -1,0 +1,64 @@
+// NOTE: The contents of this file will only be executed if
+// you uncomment its entry in "assets/js/app.js".
+
+// Bring in Phoenix channels client library:
+import { Socket } from "phoenix"
+
+// And connect to the path in "lib/twitch_gameserver_web/endpoint.ex". We pass the
+// token for authentication. Read below how it should be used.
+let socket = new Socket("/socket", { params: { token: window.userToken } })
+
+// When you connect, you'll often need to authenticate the client.
+// For example, imagine you have an authentication plug, `MyAuth`,
+// which authenticates the session and assigns a `:current_user`.
+// If the current user exists you can assign the user's token in
+// the connection for use in the layout.
+//
+// In your "lib/twitch_gameserver_web/router.ex":
+//
+//     pipeline :browser do
+//       ...
+//       plug MyAuth
+//       plug :put_user_token
+//     end
+//
+//     defp put_user_token(conn, _) do
+//       if current_user = conn.assigns[:current_user] do
+//         token = Phoenix.Token.sign(conn, "user socket", current_user.id)
+//         assign(conn, :user_token, token)
+//       else
+//         conn
+//       end
+//     end
+//
+// Now you need to pass this token to JavaScript. You can do so
+// inside a script tag in "lib/twitch_gameserver_web/templates/layout/app.html.heex":
+//
+//     <script>window.userToken = "<%= assigns[:user_token] %>";</script>
+//
+// You will need to verify the user token in the "connect/3" function
+// in "lib/twitch_gameserver_web/channels/user_socket.ex":
+//
+//     def connect(%{"token" => token}, socket, _connect_info) do
+//       # max_age: 1209600 is equivalent to two weeks in seconds
+//       case Phoenix.Token.verify(socket, "user socket", token, max_age: 1_209_600) do
+//         {:ok, user_id} ->
+//           {:ok, assign(socket, :user, user_id)}
+//
+//         {:error, reason} ->
+//           :error
+//       end
+//     end
+//
+// Finally, connect to the socket:
+socket.connect()
+
+// Now that you are connected, you can join channels with a topic.
+// Let's assume you have a channel with a topic named `room` and the
+// subtopic is its id - in this case 42:
+// let channel = socket.channel("game:42", {})
+// channel.join()
+//   .receive("ok", resp => { console.log("Joined successfully", resp) })
+//   .receive("error", resp => { console.log("Unable to join", resp) })
+
+export default socket

--- a/lib/twitch_gameserver/game/player.ex
+++ b/lib/twitch_gameserver/game/player.ex
@@ -1,0 +1,4 @@
+defmodule TwitchGameServer.Game.Player do
+  @enforce_keys [:id, :name, :login, :channel]
+  defstruct [:id, :name, :login, :channel]
+end

--- a/lib/twitch_gameserver_web/channels/game_channel.ex
+++ b/lib/twitch_gameserver_web/channels/game_channel.ex
@@ -1,0 +1,150 @@
+defmodule TwitchGameServerWeb.GameChannel do
+  use TwitchGameServerWeb, :channel
+
+  require Logger
+
+  alias TwitchGameServer.Game
+  alias TwitchGameServer.CommandServer
+
+  @impl true
+  def join("game:" <> _game_id, payload, socket) do
+    if authorized?(payload) do
+      TwitchGameServer.subscribe("commands")
+      {:ok, socket}
+    else
+      {:error, %{reason: "unauthorized"}}
+    end
+  end
+
+  # Channels can be used in a request/response fashion
+  # by sending replies to requests from the client
+  @impl true
+  def handle_in("run-commands", payload, socket) do
+    {results, errors} =
+      Enum.reduce(payload, {_results = %{}, _errors = []}, &handle_data/2)
+
+    response = %{data: results, errors: errors}
+
+    {:reply, {:ok, response}, socket}
+  end
+
+  # Add authorization logic here as required.
+  defp authorized?(_payload) do
+    true
+  end
+
+  defp map_errors(errors) do
+    Map.new(errors, fn {field, {message, _}} ->
+      {field, message}
+    end)
+  end
+
+  defp handle_data({"set_rate", rate_ms}, {results, errors}) do
+    Logger.debug("[GameChannel] setting rate to: #{rate_ms}ms")
+    CommandServer.set_rate(rate_ms)
+    results = Map.put(results, :rate, rate_ms)
+    {results, errors}
+  end
+
+  defp handle_data({"set_queue_limit", limit}, {results, errors}) do
+    Logger.debug("[GameChannel] set queue limit: #{limit}")
+    CommandServer.set_queue_limit(limit)
+    results = Map.put(results, :queue_limit, limit)
+    {results, errors}
+  end
+
+  defp handle_data(
+         {"set_filters", %{"commands" => commands, "matches" => matches}},
+         {results, errors}
+       ) do
+    Logger.debug("[GameChannel] filter: #{inspect(commands)} and #{inspect(matches)}")
+    matches = Enum.map(matches, &Regex.compile!/1)
+    CommandServer.set_filters(commands: commands, matches: matches)
+    results = Map.put(results, :filters, parse_filters(%{commands: commands, matches: matches}))
+    {results, errors}
+  end
+
+  defp handle_data({"add_command_filter", command}, {results, errors}) do
+    Logger.debug("[GameChannel] add command filter: #{command}")
+    CommandServer.add_command_filter(command)
+    results = Map.put(results, :filters, CommandServer.get_filters() |> parse_filters())
+    {results, errors}
+  end
+
+  defp handle_data({"remove_command_filter", command}, {results, errors}) do
+    Logger.debug("[GameChannel] remove command filter: #{command}")
+    CommandServer.remove_command_filter(command)
+    results = Map.put(results, :filters, CommandServer.get_filters() |> parse_filters())
+    {results, errors}
+  end
+
+  defp handle_data({"add_match_filter", match}, {results, errors}) do
+    Logger.debug("[GameChannel] add match filter: #{match}")
+    Regex.compile!(match) |> CommandServer.add_match_filter()
+    results = Map.put(results, :filters, CommandServer.get_filters() |> parse_filters())
+    {results, errors}
+  end
+
+  defp handle_data({"remove_match_filter", match}, {results, errors}) do
+    Logger.debug("[GameChannel] remove match filter: #{match}")
+    Regex.compile!(match) |> CommandServer.remove_match_filter()
+    results = Map.put(results, :filters, CommandServer.get_filters() |> parse_filters())
+    {results, errors}
+  end
+
+  defp handle_data({"flush_user", username}, {results, errors}) do
+    Logger.debug("[GameChannel] flush user queue: #{username}")
+    CommandServer.flush_user(username)
+    {results, errors}
+  end
+
+  defp handle_data({"get_leaderboard", count}, {results, errors}) do
+    Logger.debug("[GameChannel] getting leaderboard")
+
+    leaderboard =
+      Game.leaderboard(top: count)
+      |> Enum.map(fn {rank, username, score} ->
+        %{rank: rank, user: username, total: score}
+      end)
+
+    {Map.put(results, :leaderboard, leaderboard), errors}
+  end
+
+  defp handle_data({"increment_score", %{"user" => username, "inc" => inc}}, {results, errors}) do
+    Logger.debug("[GameChannel] incrementing score for: #{username}")
+
+    case Game.increment_score_by_username(username, inc) do
+      {:ok, score} ->
+        result = %{user: score.username, total: score.total}
+        {Map.put(results, :score, result), errors}
+
+      {:error, changeset} ->
+        error = %{increment_score: map_errors(changeset.errors)}
+        {results, [error | errors]}
+    end
+  end
+
+  defp handle_data({"broadcast", %{"payload" => payload}}, {results, errors}) do
+    Logger.debug("[GameChannel] broadcasting message to all users")
+    TwitchGameServer.broadcast("messages", {:server, payload})
+    {results, errors}
+  end
+
+  defp handle_data({"send", %{"user" => username, "payload" => payload}}, {results, errors}) do
+    Logger.debug("[GameChannel] sending message to user: #{username}")
+    # TODO: Switch this to use broadcast_from!
+    TwitchGameServer.broadcast("messages:#{username}", {:server, payload})
+    {results, errors}
+  end
+
+  defp handle_data(msg, {results, errors}) do
+    Logger.warning("[GameChannel] unhandled text frame: #{inspect(msg)}")
+    error = %{unrecognized: inspect(msg)}
+    {results, [error | errors]}
+  end
+
+  # Regex can't be turned into JSON, so we need to handle that for the `:matches`.
+  defp parse_filters(filters) do
+    Map.update(filters, :matches, [], &Enum.map(&1, fn regex -> Regex.source(regex) end))
+  end
+end

--- a/lib/twitch_gameserver_web/channels/new_game_socket.ex
+++ b/lib/twitch_gameserver_web/channels/new_game_socket.ex
@@ -1,0 +1,56 @@
+defmodule TwitchGameServerWeb.NewGameSocket do
+  use Phoenix.Socket
+
+  # A Socket handler
+  #
+  # It's possible to control the websocket connection and
+  # assign values that can be accessed by your channel topics.
+
+  ## Channels
+  # Uncomment the following line to define a "room:*" topic
+  # pointing to the `TwitchGameServerWeb.RoomChannel`:
+  #
+  # channel "room:*", TwitchGameServerWeb.RoomChannel
+  #
+  # To create a channel file, use the mix task:
+  #
+  #     mix phx.gen.channel Room
+  #
+  # See the [`Channels guide`](https://hexdocs.pm/phoenix/channels.html)
+  # for further details.
+
+  channel "game:*", TwitchGameServerWeb.GameChannel
+  channel "player:*", TwitchGameServerWeb.PlayerChannel
+
+  # Socket params are passed from the client and can
+  # be used to verify and authenticate a user. After
+  # verification, you can put default assigns into
+  # the socket that will be set for all channels, ie
+  #
+  #     {:ok, assign(socket, :user_id, verified_user_id)}
+  #
+  # To deny connection, return `:error` or `{:error, term}`. To control the
+  # response the client receives in that case, [define an error handler in the
+  # websocket
+  # configuration](https://hexdocs.pm/phoenix/Phoenix.Endpoint.html#socket/3-websocket-configuration).
+  #
+  # See `Phoenix.Token` documentation for examples in
+  # performing token verification on connect.
+  @impl true
+  def connect(_params, socket, _connect_info) do
+    {:ok, socket}
+  end
+
+  # Socket id's are topics that allow you to identify all sockets for a given user:
+  #
+  #     def id(socket), do: "user_socket:#{socket.assigns.user_id}"
+  #
+  # Would allow you to broadcast a "disconnect" event and terminate
+  # all active sockets and channels for a given user:
+  #
+  #     Elixir.TwitchGameServerWeb.Endpoint.broadcast("user_socket:#{user.id}", "disconnect", %{})
+  #
+  # Returning `nil` makes this socket anonymous.
+  @impl true
+  def id(_socket), do: nil
+end

--- a/lib/twitch_gameserver_web/channels/player_channel.ex
+++ b/lib/twitch_gameserver_web/channels/player_channel.ex
@@ -1,0 +1,63 @@
+defmodule TwitchGameServerWeb.PlayerChannel do
+  use TwitchGameServerWeb, :channel
+
+  alias TwitchGameServer.CommandServer
+  alias TwitchGameServer.Game.Player
+
+  require Logger
+
+  @impl true
+  def join(
+        "player:" <> _player_id,
+        %{"id" => id, "login" => login, "name" => name, "channel" => channel} = payload,
+        socket
+      ) do
+    if authorized?(payload) do
+      TwitchGameServer.subscribe("messages")
+      TwitchGameServer.subscribe("messages:{#login}")
+
+      player = %Player{
+        id: id,
+        login: login,
+        name: name,
+        channel: channel
+      }
+
+      {:ok, assign(socket, :player, player)}
+    else
+      {:error, %{reason: "unauthorized"}}
+    end
+  end
+
+  @impl true
+  def handle_in("cmd", command, socket) do
+    player = socket.assigns.player
+    Logger.debug("[PlayerChannel] <#{player.name}> #{command}")
+
+    CommandServer.add(command, %{
+      display_name: player.name,
+      user_login: player.login,
+      channel: player.channel,
+      timestamp: DateTime.utc_now()
+    })
+
+    {:reply, {:ok, %{cmd: command}}, socket}
+  end
+
+  @impl true
+  def handle_info({:server, msg}, socket) do
+    Logger.debug("[PlayerChannel] sending message...")
+    push(socket, msg, socket)
+  end
+
+  @impl true
+  def handle_info(msg, socket) do
+    Logger.warning("[PlayerChannel] unhandled message: #{inspect(msg)}")
+    {:ok, socket}
+  end
+
+  # Add authorization logic here as required.
+  defp authorized?(_payload) do
+    true
+  end
+end

--- a/lib/twitch_gameserver_web/endpoint.ex
+++ b/lib/twitch_gameserver_web/endpoint.ex
@@ -25,6 +25,12 @@ defmodule TwitchGameServerWeb.Endpoint do
       check_origin: false
     ]
 
+  socket "/socket", TwitchGameServerWeb.NewGameSocket,
+    websocket: [
+      connect_info: [],
+      check_origin: false
+    ]
+
   # Serve at "/" the static files from "priv/static" directory.
   #
   # You should set gzip to true if you are running phx.digest

--- a/test/twitch_gameserver_web/channels/game_channel_test.exs
+++ b/test/twitch_gameserver_web/channels/game_channel_test.exs
@@ -1,0 +1,146 @@
+defmodule TwitchGameServerWeb.GameChannelTest do
+  use TwitchGameServerWeb.ChannelCase
+
+  import TwitchGameServer.GameFixtures
+
+  setup do
+    {:ok, _, socket} =
+      socket(TwitchGameServerWeb.NewGameSocket)
+      |> subscribe_and_join(TwitchGameServerWeb.GameChannel, "game:123")
+
+    %{socket: socket}
+  end
+
+  defp clear_filters(socket) do
+    blank_filters = %{"set_filters" => %{"commands" => [], "matches" => []}}
+    reply = push(socket, "run-commands", blank_filters)
+    assert_reply reply, :ok, %{}
+  end
+
+  describe "set game config" do
+    test "set_filters", %{socket: socket} do
+      req = %{"set_filters" => %{"commands" => ["attack"], "matches" => ["abc"]}}
+
+      expected = %{
+        data: %{filters: %{commands: ["attack"], matches: ["abc"]}},
+        errors: []
+      }
+
+      reply = push(socket, "run-commands", req)
+      assert_reply reply, :ok, ^expected
+      clear_filters(socket)
+    end
+
+    test "set_rate", %{socket: socket} do
+      req = %{"set_rate" => 10_000}
+
+      expected = %{
+        data: %{rate: 10_000},
+        errors: []
+      }
+
+      reply = push(socket, "run-commands", req)
+      assert_reply reply, :ok, ^expected
+      clear_filters(socket)
+    end
+  end
+
+  describe "game config commands" do
+    test "add_command_filter", %{socket: socket} do
+      req = %{"add_command_filter" => "foo"}
+
+      expected = %{
+        data: %{filters: %{commands: ["foo"], matches: []}},
+        errors: []
+      }
+
+      reply = push(socket, "run-commands", req)
+      assert_reply reply, :ok, ^expected
+      clear_filters(socket)
+    end
+
+    test "remove_command_filter", %{socket: socket} do
+      req = %{"add_command_filter" => "foo"}
+
+      expected = %{
+        data: %{filters: %{commands: ["foo"], matches: []}},
+        errors: []
+      }
+
+      reply = push(socket, "run-commands", req)
+      assert_reply reply, :ok, ^expected
+
+      req = %{"remove_command_filter" => "foo"}
+
+      expected = %{
+        data: %{filters: %{commands: [], matches: []}},
+        errors: []
+      }
+
+      reply = push(socket, "run-commands", req)
+      assert_reply reply, :ok, ^expected
+      clear_filters(socket)
+    end
+
+    test "set_queue_limit", %{socket: socket} do
+      req = %{"set_queue_limit" => 500}
+
+      expected = %{
+        data: %{queue_limit: 500},
+        errors: []
+      }
+
+      reply = push(socket, "run-commands", req)
+      assert_reply reply, :ok, ^expected
+    end
+
+    test "set_rate", %{socket: socket} do
+      req = %{"set_rate" => 10_000}
+
+      expected = %{
+        data: %{rate: 10_000},
+        errors: []
+      }
+
+      reply = push(socket, "run-commands", req)
+      assert_reply reply, :ok, ^expected
+    end
+  end
+
+  describe "leaderboard" do
+    test "get_leaderboard", %{socket: socket} do
+      score_fixture(username: "a", total: 1)
+      score_fixture(username: "b", total: 100)
+      score_fixture(username: "c", total: 50)
+
+      req = %{"get_leaderboard" => 2}
+
+      expected = %{
+        data: %{
+          leaderboard: [
+            %{rank: 1, user: "b", total: 100},
+            %{rank: 2, user: "c", total: 50}
+          ]
+        },
+        errors: []
+      }
+
+      reply = push(socket, "run-commands", req)
+      assert_reply reply, :ok, ^expected
+    end
+
+    test "increment_score", %{socket: socket} do
+      score_fixture(username: "test_user_1", total: 1)
+
+      req = %{"increment_score" => %{"user" => "test_user_1", "inc" => 1}}
+
+      expected = %{
+        data: %{score: %{user: "test_user_1", total: 2}},
+        errors: []
+      }
+
+      reply = push(socket, "run-commands", req)
+      assert_reply reply, :ok, ^expected
+    end
+  end
+end

--- a/test/twitch_gameserver_web/channels/player_channel_test.exs
+++ b/test/twitch_gameserver_web/channels/player_channel_test.exs
@@ -1,0 +1,20 @@
+defmodule TwitchGameServerWeb.PlayerChannelTest do
+  use TwitchGameServerWeb.ChannelCase
+
+  setup do
+    {:ok, _, socket} =
+      socket(TwitchGameServerWeb.NewGameScoket)
+      |> subscribe_and_join(
+        TwitchGameServerWeb.PlayerChannel,
+        "player:123",
+        %{
+          id: "123",
+          login: "testuser",
+          name: "Test User",
+          channel: "testuser"
+        }
+      )
+
+    %{socket: socket}
+  end
+end


### PR DESCRIPTION
This should be a one-to-one Phoenix Channels replacement for the existing game and player sockets.  We will still need to switch to channel-based pub-sub using `broadcast_from!` instead of Phoenix.PubSub directly.  However, it should work as it does today once the javascript side connects via the channels.